### PR TITLE
Implement single vehicle class

### DIFF
--- a/formation_control/CMakeLists.txt
+++ b/formation_control/CMakeLists.txt
@@ -12,7 +12,8 @@ add_definitions(-std=c++11)
 # LIBRARIES #
 #############
 cs_add_library(${PROJECT_NAME}
-  src/formation_control.cpp 
+  src/formation_control.cpp
+  src/single_vehicle.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 

--- a/formation_control/include/formation_control/formation_control.h
+++ b/formation_control/include/formation_control/formation_control.h
@@ -41,11 +41,20 @@ class FormationController
     ros::Timer cmdloop_timer_;
     ros::Timer statusloop_timer_;
 
-    Eigen::Vector3d formation_center_;
+    Eigen::Vector3d formation_pos_;
+    Eigen::Vector4d formation_att_;
+    Eigen::Vector3d formation_linear_vel_;
+    Eigen::Vector3d formation_angular_vel_;
+    
     int num_vehicles_;
 
     void cmdloopCallback(const ros::TimerEvent& event);
     void statusloopCallback(const ros::TimerEvent& event);
+    void UpdateVrbVertexStates();
+    void CalculateVertexStates(Eigen::Vector3d vrb_position, Eigen::Vector3d &pos, Eigen::Vector3d &vel);
+    Eigen::Vector4d rot2Quaternion(Eigen::Matrix3d R);
+    Eigen::Matrix3d quat2RotMatrix(Eigen::Vector4d q);
+
 
   public:
     FormationController(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);

--- a/formation_control/include/formation_control/formation_control.h
+++ b/formation_control/include/formation_control/formation_control.h
@@ -27,6 +27,7 @@
 #include <trajectory_msgs/MultiDOFJointTrajectoryPoint.h>
 #include <trajectory_msgs/MultiDOFJointTrajectory.h>
 
+#include "formation_control/single_vehicle.h"
 
 using namespace std;
 using namespace Eigen;
@@ -35,11 +36,16 @@ class FormationController
   private:
     ros::NodeHandle nh_;
     ros::NodeHandle nh_private_;
+    std::vector<SingleVehicle> vehicle_vector_;
 
-    ros::Timer cmdloop_timer_, statusloop_timer_;
+    ros::Timer cmdloop_timer_;
+    ros::Timer statusloop_timer_;
 
-    void statusloopCallback(const ros::TimerEvent& event);
+    Eigen::Vector3d formation_center_;
+    int num_vehicles_;
+
     void cmdloopCallback(const ros::TimerEvent& event);
+    void statusloopCallback(const ros::TimerEvent& event);
 
   public:
     FormationController(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -43,10 +43,11 @@ class SingleVehicle
     void PublishSetpoint();
 
   public:
-    SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+    SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, std::string name);
     virtual ~SingleVehicle();
     void SetReferenceState(Eigen::Vector3d ref_position, Eigen::Vector3d ref_velocity);
     void SetNameSpace(std::string vehicle_name);
+    void SetVertexPosition(Eigen::Vector3d position);
     Eigen::Vector3d GetVertexPosition();
     
 };

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -8,6 +8,7 @@
 #include "mavros_msgs/State.h"
 #include "mavros_msgs/SetMode.h"
 #include "mavros_msgs/CommandBool.h"
+#include "Eigen/Dense"
 
 
 class SingleVehicle
@@ -23,15 +24,18 @@ class SingleVehicle
 
     ros::Timer cmdloop_timer_;
     ros::Timer statusloop_timer_;
-    
+
     ros::Time last_request_;
 
     mavros_msgs::State current_state_;
     mavros_msgs::SetMode offb_set_mode_;
     mavros_msgs::CommandBool arm_cmd_;
 
-    bool sim_enable_;
 
+    Eigen::Vector3d reference_pos_;
+    Eigen::Vector3d reference_vel_;
+
+    bool sim_enable_;
     
     void cmdloopCallback(const ros::TimerEvent& event);
     void statusloopCallback(const ros::TimerEvent& event);
@@ -39,9 +43,8 @@ class SingleVehicle
 
   public:
     SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
-    virtual ~SingleVehicle();    
+    virtual ~SingleVehicle();
+    void SetReferenceState(Eigen::Vector3d ref_position, Eigen::Vector3d ref_velocity);
     
 };
-
-
 #endif

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -31,12 +31,13 @@ class SingleVehicle
     mavros_msgs::SetMode offb_set_mode_;
     mavros_msgs::CommandBool arm_cmd_;
 
-
-    Eigen::Vector3d reference_pos_;
-    Eigen::Vector3d reference_vel_;
+    Eigen::Vector3d reference_pos_; // Vehicle position in world coordinate
+    Eigen::Vector3d reference_vel_; // Vehicle velocity in world coordinate
+    Eigen::Vector3d vrb_vertexpos_; // Vehicle position in virtual rigid body coordinate
 
     bool sim_enable_;
-    
+    std::string vehicle_name_;
+
     void cmdloopCallback(const ros::TimerEvent& event);
     void statusloopCallback(const ros::TimerEvent& event);
     void PublishSetpoint();
@@ -45,6 +46,7 @@ class SingleVehicle
     SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
     virtual ~SingleVehicle();
     void SetReferenceState(Eigen::Vector3d ref_position, Eigen::Vector3d ref_velocity);
+    void SetNameSpace(std::string vehicle_name);
     
 };
 #endif

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -47,6 +47,7 @@ class SingleVehicle
     virtual ~SingleVehicle();
     void SetReferenceState(Eigen::Vector3d ref_position, Eigen::Vector3d ref_velocity);
     void SetNameSpace(std::string vehicle_name);
+    Eigen::Vector3d GetVertexPosition();
     
 };
 #endif

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -5,6 +5,9 @@
 
 #include <ros/ros.h>
 #include "mavros_msgs/PositionTarget.h"
+#include "mavros_msgs/State.h"
+#include "mavros_msgs/SetMode.h"
+#include "mavros_msgs/CommandBool.h"
 
 
 class SingleVehicle
@@ -13,10 +16,22 @@ class SingleVehicle
     ros::NodeHandle nh_;
     ros::NodeHandle nh_private_;
 
-    ros::Timer cmdloop_timer_;
-    ros::Timer statusloop_timer_;
+    ros::ServiceClient arming_client_;
+    ros::ServiceClient set_mode_client_;
 
     ros::Publisher setpoint_publisher_;
+
+    ros::Timer cmdloop_timer_;
+    ros::Timer statusloop_timer_;
+    
+    ros::Time last_request_;
+
+    mavros_msgs::State current_state_;
+    mavros_msgs::SetMode offb_set_mode_;
+    mavros_msgs::CommandBool arm_cmd_;
+
+    bool sim_enable_;
+
     
     void cmdloopCallback(const ros::TimerEvent& event);
     void statusloopCallback(const ros::TimerEvent& event);

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -1,0 +1,32 @@
+//  July/2018, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+
+#ifndef SINGLE_VEHICLE_H
+#define SINGLE_VEHICLE_H
+
+#include <ros/ros.h>
+#include "mavros_msgs/PositionTarget.h"
+
+
+class SingleVehicle
+{
+  private:
+    ros::NodeHandle nh_;
+    ros::NodeHandle nh_private_;
+
+    ros::Timer cmdloop_timer_;
+    ros::Timer statusloop_timer_;
+
+    ros::Publisher setpoint_publisher_;
+    
+    void cmdloopCallback(const ros::TimerEvent& event);
+    void statusloopCallback(const ros::TimerEvent& event);
+    void PublishSetpoint();
+
+  public:
+    SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+    virtual ~SingleVehicle();    
+    
+};
+
+
+#endif

--- a/formation_control/src/formation_control.cpp
+++ b/formation_control/src/formation_control.cpp
@@ -18,8 +18,12 @@ FormationController::FormationController(const ros::NodeHandle& nh, const ros::N
   }
 
   formation_pos_ << 0.0, 0.0, 2.0;
-  formation_ang_vel_ << 0.0, 0.0, 0.0;
+  formation_angular_vel_ << 0.0, 0.0, 0.0;
   formation_linear_vel_ << 0.0, 0.0, 0.5;
+
+  vehicle_vector_[0].SetVertexPosition(Eigen::Vector3d(1.0, 0.0, 0.0));
+  vehicle_vector_[1].SetVertexPosition(Eigen::Vector3d(0.0, 1.0, 0.0));
+  vehicle_vector_[2].SetVertexPosition(Eigen::Vector3d(-1.0, 0.0, 0.0));
 
 }
 
@@ -43,7 +47,7 @@ void FormationController::UpdateVrbVertexStates(){
     Eigen::Vector3d vehicle_vel;
     Eigen::Vector3d vertex_position;
 
-    vertex_position = vehilce_vector_[i].GetVertexPosition();
+    vertex_position = vehicle_vector_[i].GetVertexPosition();
     CalculateVertexStates(vertex_position, vehicle_pos, vehicle_vel);
     vehicle_vector_[i].SetReferenceState(vehicle_pos, vehicle_vel);
   }
@@ -53,7 +57,7 @@ void FormationController::CalculateVertexStates(Eigen::Vector3d vrb_position, Ei
   Eigen::Matrix3d formation_rotmat;
 
   formation_rotmat = quat2RotMatrix(formation_att_);
-  pos = formation_pos_ + formation_rotmat * vrb_position.transpose();
+  pos = formation_pos_ + formation_rotmat * vrb_position;
   vel = formation_linear_vel_ + formation_angular_vel_.cross(vrb_position);
 
 }

--- a/formation_control/src/formation_control.cpp
+++ b/formation_control/src/formation_control.cpp
@@ -14,10 +14,12 @@ FormationController::FormationController(const ros::NodeHandle& nh, const ros::N
   statusloop_timer_ = nh_.createTimer(ros::Duration(1), &FormationController::statusloopCallback, this); // Define timer for constant loop rate
 
   for(int i = 0; i < num_vehicles_; i++){
-    vehicle_vector_.emplace_back(nh_, nh_private_);
+    vehicle_vector_.emplace_back(nh_, nh_private_, "uav" + std::string(i+1));
   }
-  
+
+  formation_center_ << 0.0, 0.0, 2.0;
 }
+
 FormationController::~FormationController() {
   //Destructor
 }

--- a/formation_control/src/formation_control.cpp
+++ b/formation_control/src/formation_control.cpp
@@ -7,11 +7,16 @@ using namespace std;
 //Constructor
 FormationController::FormationController(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
   nh_(nh),
-  nh_private_(nh_private) {
+  nh_private_(nh_private),
+  num_vehicles_(3) {
 
-  cmdloop_timer_ = nh_.createTimer(ros::Duration(0.01), &FormationController::cmdloopCallback, this); // Define timer for constant loop rate
+  cmdloop_timer_ = nh_.createTimer(ros::Duration(0.03), &FormationController::cmdloopCallback, this); // Define timer for constant loop rate
   statusloop_timer_ = nh_.createTimer(ros::Duration(1), &FormationController::statusloopCallback, this); // Define timer for constant loop rate
 
+  for(int i = 0; i < num_vehicles_; i++){
+    vehicle_vector_.emplace_back(nh_, nh_private_);
+  }
+  
 }
 FormationController::~FormationController() {
   //Destructor

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -4,17 +4,20 @@
 
 
 //Constructor
-SingleVehicle::SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
+SingleVehicle::SingleVehicle(const ros::NodeHandle& nh,
+                             const ros::NodeHandle& nh_private,
+                             std::string name):
   nh_(nh),
-  nh_private_(nh_private){
+  nh_private_(nh_private),
+  vehicle_name_(name) {
 
   cmdloop_timer_ = nh_.createTimer(ros::Duration(0.03), &SingleVehicle::cmdloopCallback, this); // Define timer for constant loop rate
   statusloop_timer_ = nh_.createTimer(ros::Duration(1), &SingleVehicle::statusloopCallback, this); // Define timer for constant loop rate
- 
-  setpoint_publisher_ = nh_.advertise<mavros_msgs::PositionTarget>("/uav1/mavros/setpoint_raw/local", 1);
-  
-  arming_client_ = nh_.serviceClient<mavros_msgs::CommandBool>("/mavros/cmd/arming");
-  set_mode_client_ = nh_.serviceClient<mavros_msgs::SetMode>("/mavros/set_mode");
+
+  setpoint_publisher_ = nh_.advertise<mavros_msgs::PositionTarget>(vehicle_name_ + "/mavros/setpoint_raw/local", 1);
+
+  arming_client_ = nh_.serviceClient<mavros_msgs::CommandBool>(vehicle_name_ + "/mavros/cmd/arming");
+  set_mode_client_ = nh_.serviceClient<mavros_msgs::SetMode>(vehicle_name_ + "/mavros/set_mode");
 }
 
 SingleVehicle::~SingleVehicle() {
@@ -67,4 +70,9 @@ void SingleVehicle::PublishSetpoint(){
   msg.velocity.z = reference_vel_(2);
 
   setpoint_publisher_.publish(msg);
+}
+
+void SingleVehicle::SetNameSpace(std::string vehicle_name){
+  vehicle_name_ = vehicle_name;
+
 }

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -76,3 +76,5 @@ void SingleVehicle::SetNameSpace(std::string vehicle_name){
   vehicle_name_ = vehicle_name;
 
 }
+
+Eigen::Vector3d SingleVehicle::GetVertexPosition(){ return vrb_vertexpos_; }

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -48,18 +48,23 @@ void SingleVehicle::statusloopCallback(const ros::TimerEvent& event){
   }
 }
 
+void SingleVehicle::SetReferenceState(Eigen::Vector3d ref_position, Eigen::Vector3d ref_velocity){
+  reference_pos_ = ref_position;
+  reference_vel_ = ref_velocity;
+
+}
+
 void SingleVehicle::PublishSetpoint(){
   mavros_msgs::PositionTarget msg;
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "map";
   msg.type_mask = 64;
-  msg.position.x = 0.0;
-  msg.position.y = 0.0;
-  msg.position.z = 0.0;
-  msg.velocity.x = 0.0;
-  msg.velocity.y = 0.0;
-  msg.velocity.z = 0.0;
+  msg.position.x = reference_pos_(0);
+  msg.position.y = reference_pos_(1);
+  msg.position.z = reference_pos_(2);
+  msg.velocity.x = reference_vel_(0);
+  msg.velocity.y = reference_vel_(1);
+  msg.velocity.z = reference_vel_(2);
 
   setpoint_publisher_.publish(msg);
-
 }

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -77,4 +77,9 @@ void SingleVehicle::SetNameSpace(std::string vehicle_name){
 
 }
 
+void SingleVehicle::SetVertexPosition(Eigen::Vector3d position){
+    vrb_vertexpos_ = position;
+
+}
+
 Eigen::Vector3d SingleVehicle::GetVertexPosition(){ return vrb_vertexpos_; }

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -1,0 +1,44 @@
+//  July/2018, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+
+#include "formation_control/single_vehicle.h"
+
+
+//Constructor
+SingleVehicle::SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
+  nh_(nh),
+  nh_private_(nh_private){
+
+  cmdloop_timer_ = nh_.createTimer(ros::Duration(0.03), &SingleVehicle::cmdloopCallback, this); // Define timer for constant loop rate
+  statusloop_timer_ = nh_.createTimer(ros::Duration(1), &SingleVehicle::statusloopCallback, this); // Define timer for constant loop rate
+ 
+  setpoint_publisher_ = nh_.advertise<mavros_msgs::PositionTarget>("/uav1/mavros/setpoint_raw/local", 1);
+}
+
+SingleVehicle::~SingleVehicle() {
+  //Destructor
+}
+
+void SingleVehicle::cmdloopCallback(const ros::TimerEvent& event){
+  PublishSetpoint();
+
+}
+
+void SingleVehicle::statusloopCallback(const ros::TimerEvent& event){
+
+}
+
+void SingleVehicle::PublishSetpoint(){
+  mavros_msgs::PositionTarget msg;
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "map";
+  msg.type_mask = 64;
+  msg.position.x = 0.0;
+  msg.position.y = 0.0;
+  msg.position.z = 0.0;
+  msg.velocity.x = 0.0;
+  msg.velocity.y = 0.0;
+  msg.velocity.z = 0.0;
+
+  setpoint_publisher_.publish(msg);
+
+}


### PR DESCRIPTION
This PR impelents a initial implementation of a `SingleVehicle` class.

The class includes:
- A publisher node that publishes setpoints to the vehicle
- A vertex position in the virtual rigid body frame
- A parameter parser for fleetwide parameter parsing
- Auto arming / offboard switching (this is only for the first implementation)