### PR TITLE
Add support for single vehicle node

### DIFF
--- a/formation_control/CMakeLists.txt
+++ b/formation_control/CMakeLists.txt
@@ -24,6 +24,12 @@ cs_add_executable(formation_control_node
   src/formation_control_node.cpp
 )
 target_link_libraries(formation_control_node ${PROJECT_NAME} ${catkin_LIBRARIES})
+
+cs_add_executable(single_vehicle_node
+  src/single_vehicle_node.cpp
+)
+target_link_libraries(single_vehicle_node ${PROJECT_NAME} ${catkin_LIBRARIES})
+
 ##########
 # EXPORT #
 ##########

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -46,6 +46,7 @@ class SingleVehicle
     void PublishSetpoint();
 
   public:
+    SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle&);
     SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, std::string name);
     virtual ~SingleVehicle();
     void SetReferenceState(Eigen::Vector3d ref_position, Eigen::Vector3d ref_velocity);

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -1,9 +1,14 @@
-//  July/2018, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+//  April/2019, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
 
 #include "formation_control/single_vehicle.h"
 
 
 //Constructor
+SingleVehicle::SingleVehicle(const ros::NodeHandle& nh,
+                             const ros::NodeHandle& nh_private)
+  : SingleVehicle(nh, nh_private, "uav1") {}
+
+
 SingleVehicle::SingleVehicle(const ros::NodeHandle& nh,
                              const ros::NodeHandle& nh_private,
                              std::string name):

--- a/formation_control/src/single_vehicle_node.cpp
+++ b/formation_control/src/single_vehicle_node.cpp
@@ -1,0 +1,13 @@
+//  July/2018, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+
+#include "formation_control/single_vehicle.h"
+
+int main(int argc, char** argv) {
+  ros::init(argc,argv,"formation_control");
+  ros::NodeHandle nh("");
+  ros::NodeHandle nh_private("~");
+
+  SingleVehicle singlevehicleController(nh, nh_private);
+  ros::spin();
+  return 0;
+}


### PR DESCRIPTION
This PR adds support for executing the single vehicle node independently

The name of the vehicle is hardcoded as `uav1` for now