### PR TITLE
Use global position setpoints for formation control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,9 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt-get update -qq
   - sudo apt-get install dpkg
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base
-  - sudo apt-get install -y python-catkin-tools python-rosinstall-generator ros-$ROS_DISTRO-geographic-msgs -y
-  - sudo apt-get install -y ros-kinetic-mavros ros-kinetic-mavros-extras libeigen3-dev geographiclib-tools libgeographic-dev ros-$ROS_DISTRO-gazebo-msgs
+  - sudo apt-get install -y --allow-unauthenticated python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base
+  - sudo apt-get install -y --allow-unauthenticated python-catkin-tools python-rosinstall-generator ros-$ROS_DISTRO-geographic-msgs -y
+  - sudo apt-get install -y --allow-unauthenticated ros-kinetic-mavros ros-kinetic-mavros-extras libeigen3-dev geographiclib-tools libgeographic-dev ros-$ROS_DISTRO-gazebo-msgs
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/formation_control/include/formation_control/formation_control.h
+++ b/formation_control/include/formation_control/formation_control.h
@@ -23,7 +23,7 @@
 #include <mavros_msgs/State.h>
 #include <mavros_msgs/CommandBool.h>
 #include <std_srvs/SetBool.h>
-
+#include "geodetic_utils/geodetic_conv.hpp"
 
 #include "formation_control/single_vehicle.h"
 
@@ -44,6 +44,9 @@ class FormationController
     Eigen::Vector4d formation_att_;
     Eigen::Vector3d formation_linear_vel_;
     Eigen::Vector3d formation_angular_vel_;
+    Eigen::Vector3d global_origin_;
+  
+    geodetic_converter::GeodeticConverter geod_converter_global_origin_;
     
     int num_vehicles_;
     double loop_dt_;

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -5,6 +5,7 @@
 
 #include <ros/ros.h>
 #include "mavros_msgs/PositionTarget.h"
+#include "mavros_msgs/GlobalPositionTarget.h"
 #include "mavros_msgs/State.h"
 #include "mavros_msgs/SetMode.h"
 #include "mavros_msgs/CommandBool.h"
@@ -43,7 +44,8 @@ class SingleVehicle
     void cmdloopCallback(const ros::TimerEvent& event);
     void statusloopCallback(const ros::TimerEvent& event);
     void mavstateCallback(const mavros_msgs::State::ConstPtr& msg);
-    void PublishSetpoint();
+    void PublishGlobalSetpoint();
+    void PublishLocalSetpoint();
 
   public:
     SingleVehicle(const ros::NodeHandle& nh, const ros::NodeHandle&);

--- a/formation_control/include/formation_control/single_vehicle.h
+++ b/formation_control/include/formation_control/single_vehicle.h
@@ -11,6 +11,11 @@
 #include "mavros_msgs/CommandBool.h"
 #include "Eigen/Dense"
 
+enum SETPOINT_TYPE
+{
+    LOCAL_SETPOINT,
+    GLOBAL_SETPOINT
+};
 
 class SingleVehicle
 {
@@ -21,13 +26,16 @@ class SingleVehicle
     ros::ServiceClient arming_client_;
     ros::ServiceClient set_mode_client_;
 
-    ros::Publisher setpoint_publisher_;
+    ros::Publisher localsetpoint_publisher_;
+    ros::Publisher globalsetpoint_publisher_;
     ros::Subscriber mavstateSub_;
 
     ros::Timer cmdloop_timer_;
     ros::Timer statusloop_timer_;
 
     ros::Time last_request_;
+
+    SETPOINT_TYPE setpoint_type_;
 
     mavros_msgs::State current_state_;
     mavros_msgs::SetMode offb_set_mode_;

--- a/formation_control/package.xml
+++ b/formation_control/package.xml
@@ -17,6 +17,7 @@
   <build_depend>tf</build_depend>
   <build_depend>mavros_msgs</build_depend>
   <build_depend> eigen_catkin</build_depend>
+  <build_depend>geodetic_utils</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>catkin_simple</run_depend>
@@ -26,6 +27,7 @@
   <run_depend>tf</run_depend>
   <run_depend>mavros</run_depend>
   <run_depend>mavros_msgs</run_depend>
+  <run_depend>geodetic_utils</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/formation_control/src/formation_control.cpp
+++ b/formation_control/src/formation_control.cpp
@@ -19,19 +19,19 @@ FormationController::FormationController(const ros::NodeHandle& nh, const ros::N
 
   vehicle_vector_.resize(num_vehicles_);
   for(auto i = 0; i < num_vehicles_; i++){
-    std::string vehicle_name = name_prefix_ + std::to_string(i+1);
+    std::string vehicle_name = name_prefix_ + std::to_string(i);
     vehicle_vector_[i].reset(new SingleVehicle(nh_, nh_private_, vehicle_name));
   }
 
-  formation_pos_ << 0.0, 0.0, 10.0;
-  formation_angular_vel_ << 0.0, 0.0, 0.0;
+  formation_pos_ << 0.0, 0.0, 3.0;
+  formation_angular_vel_ << 0.0, 0.0, 0.3;
   formation_linear_vel_ << 0.0, 0.0, 0.0;
   formation_att_ << 1.0, 0.0, 0.0, 0.0;
   global_origin_ << 47.397742, 8.545594, 488;
 
   vehicle_vector_[0]->SetVertexPosition(Eigen::Vector3d(2.0, 0.0, 0.0));
-  vehicle_vector_[1]->SetVertexPosition(Eigen::Vector3d(0.0, 2.0, 0.0));
-  vehicle_vector_[2]->SetVertexPosition(Eigen::Vector3d(-2.0, 0.0, 0.0));
+  vehicle_vector_[1]->SetVertexPosition(Eigen::Vector3d(-2.0, 0.0, 0.0));
+  vehicle_vector_[2]->SetVertexPosition(Eigen::Vector3d(0.0, 2.0, 0.0));
 
   geod_converter_global_origin_.initialiseReference(global_origin_(0), global_origin_(1), global_origin_(2));
 
@@ -52,14 +52,14 @@ void FormationController::cmdloopCallback(const ros::TimerEvent& event){
   Eigen::Vector4d d_formation_att;
   Eigen::Vector3d omega = formation_angular_vel_;
 
-  // Qx <<      0.0, -omega(0), -omega(1), -omega(2),
-  //        omega(0),       0.0,  omega(2), -omega(1),
-  //        omega(1), -omega(2),       0.0,  omega(0),
-  //        omega(2),  omega(1), -omega(0),       0.0;
+  Qx <<      0.0, -omega(0), -omega(1), -omega(2),
+         omega(0),       0.0,  omega(2), -omega(1),
+         omega(1), -omega(2),       0.0,  omega(0),
+         omega(2),  omega(1), -omega(0),       0.0;
 
-  // formation_pos_ = formation_pos_ + formation_linear_vel_ * loop_dt_;
-    // d_formation_att = Qx * formation_att_;
-  // formation_att_ = formation_att_ + d_formation_att * loop_dt_;
+  formation_pos_ = formation_pos_ + formation_linear_vel_ * loop_dt_;
+  d_formation_att = Qx * formation_att_;
+  formation_att_ = formation_att_ + d_formation_att * loop_dt_;
   /**
   * @todo Implement boid controller
   * @body Implement boid controller for flocking behavior

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -20,7 +20,7 @@ SingleVehicle::SingleVehicle(const ros::NodeHandle& nh,
   statusloop_timer_ = nh_.createTimer(ros::Duration(1), &SingleVehicle::statusloopCallback, this); // Define timer for constant loop rate
 
   localsetpoint_publisher_ = nh_.advertise<mavros_msgs::PositionTarget>("/"+vehicle_name_+"/mavros/setpoint_raw/local", 1);
-  globalsetpoint_publisher_ = nh_.advertise<mavros_msgs::GlobalPositionTarget>("/"+vehicle_name_+"/mavros/setpoint_position/global", 1);
+  globalsetpoint_publisher_ = nh_.advertise<mavros_msgs::GlobalPositionTarget>("/"+vehicle_name_+"/mavros/setpoint_raw/global", 1);
 
   mavstateSub_ = nh_.subscribe("/"+vehicle_name_+"/mavros/state", 1, &SingleVehicle::mavstateCallback, this,ros::TransportHints().tcpNoDelay());
 

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -38,7 +38,7 @@ SingleVehicle::~SingleVehicle() {
 }
 
 void SingleVehicle::cmdloopCallback(const ros::TimerEvent& event){
-  PublishSetpoint();
+  PublishLocalSetpoint();
 
 }
 
@@ -78,7 +78,7 @@ void SingleVehicle::SetReferenceState(Eigen::Vector3d ref_position, Eigen::Vecto
 
 }
 
-void SingleVehicle::PublishSetpoint(){
+void SingleVehicle::PublishLocalSetpoint(){
 
   mavros_msgs::PositionTarget msg;
   msg.header.stamp = ros::Time::now();
@@ -87,6 +87,24 @@ void SingleVehicle::PublishSetpoint(){
   msg.position.x = reference_pos_(0);
   msg.position.y = reference_pos_(1);
   msg.position.z = reference_pos_(2);
+  msg.velocity.x = reference_vel_(0);
+  msg.velocity.y = reference_vel_(1);
+  msg.velocity.z = reference_vel_(2);
+  msg.yaw =0.0;
+  msg.yaw_rate = 0.0;
+
+  setpoint_publisher_.publish(msg);
+}
+
+void SingleVehicle::PublishGlobalSetpoint(){
+
+  mavros_msgs::GlobalPositionTarget msg;
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "map";
+  msg.type_mask = 64;
+  msg.latitude = reference_pos_(0);
+  msg.longitude = reference_pos_(0);
+  msg.altitude = reference_pos_(1);
   msg.velocity.x = reference_vel_(0);
   msg.velocity.y = reference_vel_(1);
   msg.velocity.z = reference_vel_(2);

--- a/formation_control/src/single_vehicle.cpp
+++ b/formation_control/src/single_vehicle.cpp
@@ -19,7 +19,8 @@ SingleVehicle::SingleVehicle(const ros::NodeHandle& nh,
   cmdloop_timer_ = nh_.createTimer(ros::Duration(0.03), &SingleVehicle::cmdloopCallback, this); // Define timer for constant loop rate
   statusloop_timer_ = nh_.createTimer(ros::Duration(1), &SingleVehicle::statusloopCallback, this); // Define timer for constant loop rate
 
-  setpoint_publisher_ = nh_.advertise<mavros_msgs::PositionTarget>("/"+vehicle_name_+"/mavros/setpoint_raw/local", 1);
+  localsetpoint_publisher_ = nh_.advertise<mavros_msgs::PositionTarget>("/"+vehicle_name_+"/mavros/setpoint_raw/local", 1);
+  globalsetpoint_publisher_ = nh_.advertise<mavros_msgs::GlobalPositionTarget>("/"+vehicle_name_+"/mavros/setpoint_position/global", 1);
 
   mavstateSub_ = nh_.subscribe("/"+vehicle_name_+"/mavros/state", 1, &SingleVehicle::mavstateCallback, this,ros::TransportHints().tcpNoDelay());
 
@@ -31,6 +32,7 @@ SingleVehicle::SingleVehicle(const ros::NodeHandle& nh,
   set_mode_client_ = nh_.serviceClient<mavros_msgs::SetMode>("/"+vehicle_name_+"/mavros/set_mode");
 
   sim_enable_ = true;
+  setpoint_type_ = SETPOINT_TYPE::GLOBAL_SETPOINT;
 }
 
 SingleVehicle::~SingleVehicle() {
@@ -38,8 +40,16 @@ SingleVehicle::~SingleVehicle() {
 }
 
 void SingleVehicle::cmdloopCallback(const ros::TimerEvent& event){
-  PublishLocalSetpoint();
+  switch(setpoint_type_){
+    case SETPOINT_TYPE::LOCAL_SETPOINT :
+      PublishLocalSetpoint();
+      break;
+    
+    case SETPOINT_TYPE::GLOBAL_SETPOINT :
+      PublishGlobalSetpoint();
+      break;
 
+  }
 }
 
 void SingleVehicle::statusloopCallback(const ros::TimerEvent& event){
@@ -93,7 +103,7 @@ void SingleVehicle::PublishLocalSetpoint(){
   msg.yaw =0.0;
   msg.yaw_rate = 0.0;
 
-  setpoint_publisher_.publish(msg);
+  localsetpoint_publisher_.publish(msg);
 }
 
 void SingleVehicle::PublishGlobalSetpoint(){
@@ -103,15 +113,15 @@ void SingleVehicle::PublishGlobalSetpoint(){
   msg.header.frame_id = "map";
   msg.type_mask = 64;
   msg.latitude = reference_pos_(0);
-  msg.longitude = reference_pos_(0);
-  msg.altitude = reference_pos_(1);
+  msg.longitude = reference_pos_(1);
+  msg.altitude = reference_pos_(2);
   msg.velocity.x = reference_vel_(0);
   msg.velocity.y = reference_vel_(1);
   msg.velocity.z = reference_vel_(2);
   msg.yaw =0.0;
   msg.yaw_rate = 0.0;
 
-  setpoint_publisher_.publish(msg);
+  globalsetpoint_publisher_.publish(msg);
 }
 
 void SingleVehicle::SetNameSpace(std::string vehicle_name){


### PR DESCRIPTION
Since PX4 firmware supports global_position setpoints through `SET_POSITION_TARGET_GLOBAL_INT`, with https://github.com/PX4/Firmware/pull/12819 it is more simpler to use global position setpoints to control the formation of multiple drones.

This PR changes the interface to global position setpoints to control each vehicle of the formation. The conversion to local coordinate therefore is done on the vehicle. 