### PR TITLE
Fix global altitude conversions

### DIFF
--- a/formation_control/src/formation_control.cpp
+++ b/formation_control/src/formation_control.cpp
@@ -28,7 +28,7 @@ FormationController::FormationController(const ros::NodeHandle& nh, const ros::N
   formation_angular_vel_ << 0.0, 0.0, 0.3;
   formation_linear_vel_ << 0.0, 0.0, 0.0;
   formation_att_ << 1.0, 0.0, 0.0, 0.0;
-  global_origin_ << 47.397742, 8.545594, 488;
+  global_origin_ << 47.397742, 8.545594, 2.0;
 
   vehicle_vector_[0]->SetVertexPosition(Eigen::Vector3d(2.0, 0.0, 0.0));
   vehicle_vector_[1]->SetVertexPosition(Eigen::Vector3d(-2.0, 0.0, 0.0));


### PR DESCRIPTION
There was something wrong with the global altitude conversion, and the vehicles were hovering in the global altitude in the local coordiates (488m). This is a quick fix to make it hover near the ground

Fixes #31 